### PR TITLE
fix: add round-trip conversion tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@adobe/eslint-config-helix": "1.3.2",
         "@adobe/helix-deploy": "7.3.2",
+        "@adobe/helix-html-pipeline": "^3.7.6",
         "@adobe/helix-universal": "3.3.1",
         "@adobe/semantic-release-coralogix": "1.1.11",
         "@semantic-release/changelog": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@adobe/eslint-config-helix": "1.3.2",
     "@adobe/helix-deploy": "7.3.2",
+    "@adobe/helix-html-pipeline": "^3.7.6",
     "@adobe/helix-universal": "3.3.1",
     "@adobe/semantic-release-coralogix": "1.1.11",
     "@semantic-release/changelog": "6.0.1",

--- a/test/roundtrip/README.md
+++ b/test/roundtrip/README.md
@@ -1,0 +1,18 @@
+Round-trip tests: html -> markdown -> html
+----
+
+These tests run the complete `html -> markdown -> html` pipeline using
+Semantic HTML in the format expected by the Helix pipeline as input.
+
+The goal is to explore the details of this input format, and check
+what's kept or lost in the double conversion.
+
+The Helix Semantic HTML format is currently being defined, see
+
+* https://github.com/adobe/helix-html2md/issues/4
+* https://github.com/adobe/helix-html2md/discussions/6
+* https://github.com/adobe/helix-html2md/discussions/7
+* The tests and fixtures under https://github.com/adobe/helix-html2md/tree/main/test are a good way to find out what's supported.
+
+These tests might lead to improvement proposals to help support the
+various content types that we need to inject in the Content Bus.

--- a/test/roundtrip/mock-pipeline.js
+++ b/test/roundtrip/mock-pipeline.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { PipelineRequest, PipelineState, htmlPipe } from '@adobe/helix-html-pipeline';
+import { PipelineResponse } from '@adobe/helix-html-pipeline/src/PipelineResponse.js';
+
+export const render = async (url, source) => {
+  const req = new PipelineRequest(url, {
+    headers: new Map([['host', url.hostname]]),
+    body: '',
+  });
+
+  const s3Loader = {
+    async getObject(_bucketId, key) {
+      if (key.endsWith('.md')) {
+        return new PipelineResponse(source);
+      }
+      if (key === 'adobe/helix-pages/super-test/helix-config.json') {
+        return new PipelineResponse('{}');
+      }
+      return new PipelineResponse('', { status: 404 });
+    },
+
+    // eslint-disable-next-line no-unused-vars
+    async headObject(_bucketId, _key) {
+      return new PipelineResponse('', { status: 404 });
+    },
+  };
+
+  const log = null;
+
+  const state = new PipelineState({
+    log,
+    s3Loader,
+    owner: 'adobe',
+    repo: 'helix-pages',
+    ref: 'super-test',
+    partition: 'live',
+    path: url.pathname,
+    contentBusId: 'foo-id',
+    timer: {
+      update: () => {},
+    },
+  });
+
+  return htmlPipe(state, req);
+};

--- a/test/roundtrip/roundtrip-fixtures/all-sections.input.html
+++ b/test/roundtrip/roundtrip-fixtures/all-sections.input.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>All sections</title>
+  </head>
+  <body>
+    <header><div class="hclass">Header text, currently ignored.</div>></header>
+    <main><div class="mclass">Main text</div>></main>
+    <footer><div class="fclass">Footer text, currently ignored.</div>></footer>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/all-sections.output.html
+++ b/test/roundtrip/roundtrip-fixtures/all-sections.output.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>All sections</title>
+    <link rel="canonical" href="https://undefined/">
+    <meta property="og:title" content="All sections">
+    <meta property="og:url" content="https://undefined/">
+    <meta property="og:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="All sections">
+    <meta name="twitter:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module" crossorigin="use-credentials"></script>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div>
+        <p>Main text</p>
+      </div>
+      <div></div>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/empty.input.html
+++ b/test/roundtrip/roundtrip-fixtures/empty.input.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>An empty document, for which the title will be ignored</title>
+  </head>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/empty.output.html
+++ b/test/roundtrip/roundtrip-fixtures/empty.output.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title></title>
+    <link rel="canonical" href="https://undefined/">
+    <meta property="og:url" content="https://undefined/">
+    <meta property="og:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module" crossorigin="use-credentials"></script>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div></div>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/microdata.input.html
+++ b/test/roundtrip/roundtrip-fixtures/microdata.input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Microdata example</title>
+  </head>
+  <body>
+    <main>
+      <div>The list has microdata, which is stripped out:
+        <ul itemscope>
+          <li itemprop="firstname">Leonardo</li>
+          <li itemprop="lastname">Da Vinci</li>
+          <li itemprop="city">Rome</li>
+          <li itemprop="country">Italy</li>
+        </ul>
+      </div>
+    </main>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/microdata.output.html
+++ b/test/roundtrip/roundtrip-fixtures/microdata.output.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Microdata example</title>
+    <link rel="canonical" href="https://undefined/">
+    <meta property="og:title" content="Microdata example">
+    <meta property="og:url" content="https://undefined/">
+    <meta property="og:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Microdata example">
+    <meta name="twitter:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module" crossorigin="use-credentials"></script>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div>
+        <p>The list has microdata, which is stripped out:</p>
+        <ul>
+          <li>Leonardo</li>
+          <li>Da Vinci</li>
+          <li>Rome</li>
+          <li>Italy</li>
+        </ul>
+      </div>
+      <div></div>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/some-text.input.html
+++ b/test/roundtrip/roundtrip-fixtures/some-text.input.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The basic title</title>
+  </head>
+  <body>
+    <main>
+      <h1>The h1 title, currently ignored.</h1>
+      <div>The first div with some <strong>strong</strong> text</div>
+      <section data-note="currently ignored?">
+        <h2>The section title</h2>
+        <div>And the section text, <em>emphasized</em>, also ignored.</div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip-fixtures/some-text.output.html
+++ b/test/roundtrip/roundtrip-fixtures/some-text.output.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>The basic title</title>
+    <link rel="canonical" href="https://undefined/">
+    <meta property="og:title" content="The basic title">
+    <meta property="og:url" content="https://undefined/">
+    <meta property="og:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="The basic title">
+    <meta name="twitter:image" content="https://undefined/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/scripts.js" type="module" crossorigin="use-credentials"></script>
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div>
+        <p>The first div with some <strong>strong</strong> text</p>
+      </div>
+      <div></div>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/test/roundtrip/roundtrip.test.js
+++ b/test/roundtrip/roundtrip.test.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import assert from 'assert';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { html2md } from '../../src/html2md.js';
+import { render } from './mock-pipeline.js';
+
+const url = 'http://example.com';
+
+const specs = [
+  'empty',
+  'some-text',
+  'all-sections',
+  'microdata',
+];
+
+describe('Roundtrip tests', () => {
+  specs.forEach((spec) => {
+    it(`converts '${spec}' HTML input to the expected output`, async () => {
+      const input = await readFile(resolve(__testdir, 'roundtrip/roundtrip-fixtures', `${spec}.input.html`), 'utf-8');
+      const expected = await readFile(resolve(__testdir, 'roundtrip/roundtrip-fixtures', `${spec}.output.html`), 'utf-8');
+      const markdown = await html2md(input, { log: console });
+      const output = await render(url, markdown);
+      assert.strictEqual(output.body?.trim(), expected.trim());
+    });
+  });
+});


### PR DESCRIPTION
This adds a set of round-trip tests, converting from HTML to Markdown using this module and back to HTML using `@adobe/helix-html-pipeline`.

I think this can be useful to clarify and demonstrate what's accepted in the input, and verify what comes out of the Helix pipeline after the reverse conversion, to complement the Semantic HTML format specification.

The tests use a strict String comparison of the output, so they would be brittle if the output format changes. I think that's good enough to start with, and if needed we can later move to parsing the output and checking based on CSS selectors or something to make the tests more robust.