### PR TITLE
feat: forward x-contnet-source-location to origin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,11 @@ async function run(request, ctx) {
     reqHeaders.authorization = auth;
   }
 
+  const sourceLocation = request.headers.get('x-content-source-location');
+  if (sourceLocation) {
+    reqHeaders['x-content-source-location'] = sourceLocation;
+  }
+
   const res = await fetch(url, {
     headers: reqHeaders,
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -202,6 +202,7 @@ describe('Index Tests', () => {
     nock('https://www.example.com', {
       reqheaders: {
         authorization: 'Bearer 1234',
+        'x-content-source-location': '/content/some-path/index?sig=signature&exp=2024-03-03T10:00:00.000Z',
       },
     })
       .get('/index.html')
@@ -209,7 +210,21 @@ describe('Index Tests', () => {
         'last-modified': 'Sat, 22 Feb 2031 15:28:00 GMT',
       });
     const expected = await readFile(resolve(__testdir, 'fixtures', 'simple.md'), 'utf-8');
-    const result = await main(reqUrl('/index.html', { headers: { authorization: 'Bearer 1234' } }), { log: console, env: DUMMY_ENV });
+    const result = await main(
+      reqUrl(
+        '/index.html',
+        {
+          headers: {
+            authorization: 'Bearer 1234',
+            'x-content-source-location': '/content/some-path/index?sig=signature&exp=2024-03-03T10:00:00.000Z',
+          },
+        },
+      ),
+      {
+        log: console,
+        env: DUMMY_ENV,
+      },
+    );
     assert.strictEqual(result.status, 200);
     assert.strictEqual((await result.text()).trim(), expected.trim());
     assert.deepStrictEqual(result.headers.plain(), {


### PR DESCRIPTION
Forward `x-content-source-location` to the configured origin if sent by `helix-admin`

## Related Issues

- fixes #401 
- relates to https://github.com/adobe/helix-admin/pull/1885
