### PR TITLE
fix: log stack in debug level (AWS)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,8 @@ async function run(request, ctx) {
     if (e instanceof TooManyImagesError) {
       return error(`error fetching resource at ${sourceUrl}: ${e.message}`, 409);
     }
-    /* c8 ignore next 2 */
+    /* c8 ignore next 3 */
+    log.debug(e.stack);
     return error(`error fetching resource at ${sourceUrl}: ${e.message}`, 500);
   } finally {
     await mediaHandler?.fetchContext.reset();


### PR DESCRIPTION
We're currently seeing a lot requests returning the error message:
```
error fetching resource at https://[...]: Cannot read properties of undefined (reading 'slice')
```
which makes it practically impossible to determine where something went wrong.