### PR TITLE
fix: up byom image limit to 120

### DIFF
--- a/src/mdast-process-images.js
+++ b/src/mdast-process-images.js
@@ -50,8 +50,8 @@ export async function processImages(log, tree, mediaHandler, baseUrl) {
     return CONTINUE;
   });
 
-  if (images.size > 100) {
-    throw new TooManyImagesError(`maximum number of images reached: ${images.size} of 100 max.`);
+  if (images.size > 120) {
+    throw new TooManyImagesError(`maximum number of images reached: ${images.size} of 120 max.`);
   }
 
   // upload images

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -286,7 +286,7 @@ describe('Index Tests', () => {
 
   it('returns 409 for too many different images', async () => {
     let html = '<html><body><main><div>';
-    for (let i = 0; i < 101; i += 1) {
+    for (let i = 0; i < 121; i += 1) {
       html += `<img src="/image-${i}.png">`;
     }
     html += '</div></main></body>';
@@ -301,7 +301,7 @@ describe('Index Tests', () => {
     assert.deepStrictEqual(result.headers.plain(), {
       'cache-control': 'no-store, private, must-revalidate',
       'content-type': 'text/plain; charset=utf-8',
-      'x-error': 'error fetching resource at https://www.example.com/: maximum number of images reached: 101 of 100 max.',
+      'x-error': 'error fetching resource at https://www.example.com/: maximum number of images reached: 121 of 120 max.',
     });
   });
 


### PR DESCRIPTION
Increase BYOM image limit to 120 images.

In a future PR we will not count duplicate images (based on hash) towards to limit.