### PR TITLE
feat: add better image size error

### DIFF
--- a/test/fixtures/images-large.html
+++ b/test/fixtures/images-large.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+    <title>Simple Document with Images</title>
+</head>
+<body>
+<main>
+    <div>
+        <h1>Hello, World.</h1>
+        <picture>
+            <img src="/large.png">
+        </picture>
+    </div>
+    <div>
+        <h1>Hello, World.</h1>
+        <picture>
+            <img src="/large1.png">
+        </picture>
+    </div>
+</main>
+</body>
+</html>

--- a/test/mdast-process-images.test.js
+++ b/test/mdast-process-images.test.js
@@ -12,7 +12,23 @@
 
 /* eslint-env mocha */
 import assert from 'assert';
-import { processImages, TooManyImagesError } from '../src/mdast-process-images.js';
+import { processImages, TooManyImagesError, toSISize } from '../src/mdast-process-images.js';
+
+describe('Utils Test', () => {
+  it('calculates the correct si size', () => {
+    assert.strictEqual(toSISize(0), '0B');
+    assert.strictEqual(toSISize(100), '100B');
+    assert.strictEqual(toSISize(-100), '-100B');
+    assert.strictEqual(toSISize(1024), '1.00KB');
+    assert.strictEqual(toSISize(1024 + 512), '1.50KB');
+    assert.strictEqual(toSISize(-1024 - 512), '-1.50KB');
+    assert.strictEqual(toSISize(1024 * 1024), '1.00MB');
+    assert.strictEqual(toSISize(1024 * 1024, 0), '1MB');
+    assert.strictEqual(toSISize(1024 * 1024 * 1024), '1.00GB');
+    assert.strictEqual(toSISize(2048 * 1024 * 1024 * 1024), '2.00TB');
+    assert.strictEqual(toSISize(-2048 * 1024 * 1024 * 1024), '-2.00TB');
+  });
+});
 
 describe('mdast-process-images Tests', () => {
   let processedUrls;


### PR DESCRIPTION
adds better error information:

```
'x-error': 'error fetching resource at https://www.example.com/: Images 1 and 2 exceed allowed limit of 10.00MB',
```